### PR TITLE
Compatible with flyme10

### DIFF
--- a/app/src/main/java/io/github/lsposed/disableflagsecure/DisableFlagSecure.java
+++ b/app/src/main/java/io/github/lsposed/disableflagsecure/DisableFlagSecure.java
@@ -78,7 +78,8 @@ public class DisableFlagSecure implements IXposedHookLoadPackage {
             } catch (Throwable t) {
                 XposedBridge.log(t);
             }
-        }
+        } else
+            XposedHelpers.findAndHookMethod("android.view.SurfaceControl$ScreenshotHardwareBuffer", loadPackageParam.classLoader, "containsSecureLayers", XC_MethodReplacement.returnConstant(false));
     }
 
 

--- a/app/src/main/java/io/github/lsposed/disableflagsecure/DisableFlagSecure.java
+++ b/app/src/main/java/io/github/lsposed/disableflagsecure/DisableFlagSecure.java
@@ -78,8 +78,13 @@ public class DisableFlagSecure implements IXposedHookLoadPackage {
             } catch (Throwable t) {
                 XposedBridge.log(t);
             }
-        } else
-            XposedHelpers.findAndHookMethod("android.view.SurfaceControl$ScreenshotHardwareBuffer", loadPackageParam.classLoader, "containsSecureLayers", XC_MethodReplacement.returnConstant(false));
+        } else if (loadPackageParam.packageName.equals("com.flyme.systemuiex")) {
+            try {
+                XposedHelpers.findAndHookMethod("android.view.SurfaceControl$ScreenshotHardwareBuffer", loadPackageParam.classLoader, "containsSecureLayers", XC_MethodReplacement.returnConstant(false));
+            }catch (Throwable t) {
+                XposedBridge.log(t);
+            }
+        }
     }
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,5 +3,6 @@
     <string name="xposed_description">Disable FLAG_SECURE on all windows, enabling screenshots in apps that normally wouldn\'t allow it.</string>
     <string-array name="scope">
         <item>android</item>
+        <item>com.flyme.systemuiex</item>
     </string-array>
 </resources>


### PR DESCRIPTION
English(Google Translate)
android.view.SurfaceControl$ScreenshotHardwareBuffer is bootclass,
So the scope needs to include com.flyme.systemuiex

中文
android.view.SurfaceControl$ScreenshotHardwareBuffer是bootclass,
所以作用域需要包含com.flyme.systemuiex