### PR TITLE
fix: support secure capture on One UI 8 

### DIFF
--- a/app/src/main/java/io/github/lsposed/disableflagsecure/DisableFlagSecure.java
+++ b/app/src/main/java/io/github/lsposed/disableflagsecure/DisableFlagSecure.java
@@ -192,6 +192,15 @@ public class DisableFlagSecure extends XposedModule {
                         log(Log.ERROR, TAG, "hook ScreenCapture failed", t);
                     }
                 }
+                if (SYSTEMUI.equals(packageName) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+                    try {
+                        hookOneUiSystemUiScreenshot(classLoader);
+                    } catch (Throwable t) {
+                        if (!(t instanceof ClassNotFoundException)) {
+                            log(Log.ERROR, TAG, "hook OneUI SystemUI screenshot failed", t);
+                        }
+                    }
+                }
                 break;
             default:
                 try {
@@ -444,9 +453,47 @@ public class DisableFlagSecure extends XposedModule {
         hookMethods(longshotMainClazz, chain -> false, "hasSecure");
     }
 
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private void hookOneUiSystemUiScreenshot(ClassLoader classLoader) throws ClassNotFoundException {
+        var screenshotDataClazz = classLoader.loadClass("com.android.systemui.screenshot.ScreenshotData");
+        var hookedConstructorCount = 0;
+        for (var constructor : screenshotDataClazz.getDeclaredConstructors()) {
+            if (!OneUiSystemUiScreenshotHook.isScreenshotDataConstructor(constructor)) {
+                continue;
+            }
+            hookedConstructorCount++;
+            hookE(constructor).intercept(chain -> {
+                var args = chain.getArgs().toArray();
+                OneUiSystemUiScreenshotHook.clearWorkProfileSecureLayer(args);
+                return chain.proceed(args);
+            });
+        }
+        if (hookedConstructorCount > 0) {
+            log(Log.INFO, TAG, "Hooked One UI Work Profile ScreenshotData constructors (count="
+                    + hookedConstructorCount + ")");
+        } else {
+            log(Log.WARN, TAG, "no supported ScreenshotData constructor was found");
+        }
+    }
+
     private void hookOneUI(ClassLoader classLoader) throws ClassNotFoundException {
         var wmScreenshotControllerClazz = classLoader.loadClass("com.android.server.wm.WmScreenshotController");
         hookMethods(wmScreenshotControllerClazz, chain -> true, "canBeScreenshotTarget");
+
+        Arrays.stream(wmScreenshotControllerClazz.getDeclaredMethods())
+                .filter(OneUiWmScreenshotHook::isScreenshotAllowedByPolicyMethod)
+                .forEach(method -> hookE(method).intercept(chain -> {
+                    var allowed = (boolean) chain.proceed();
+                    return OneUiWmScreenshotHook.narrowScreenshotPolicyResult(chain.getThisObject(), allowed);
+                }));
+
+        Arrays.stream(wmScreenshotControllerClazz.getDeclaredMethods())
+                .filter(OneUiWmScreenshotHook::isPrimaryProfileScreenshotMethod)
+                .forEach(method -> hookE(method).intercept(chain -> {
+                    var args = chain.getArgs().toArray();
+                    OneUiWmScreenshotHook.forceIgnoreSecureContentPolicy(args);
+                    return chain.proceed(args);
+                }));
     }
 
     private void hookMethods(Class<?> clazz, Hooker hooker, String... names) {

--- a/app/src/main/java/io/github/lsposed/disableflagsecure/OneUiSystemUiScreenshotHook.java
+++ b/app/src/main/java/io/github/lsposed/disableflagsecure/OneUiSystemUiScreenshotHook.java
@@ -1,0 +1,47 @@
+package io.github.lsposed.disableflagsecure;
+
+import java.lang.reflect.Constructor;
+
+final class OneUiSystemUiScreenshotHook {
+    static final int TYPE_ARG_INDEX = 0;
+    static final int SECURE_LAYER_ARG_INDEX = 10;
+    static final int WORK_PROFILE_SCREENSHOT_TYPE = 3;
+
+    private OneUiSystemUiScreenshotHook() {
+    }
+
+    static boolean isScreenshotDataConstructor(Constructor<?> constructor) {
+        if (constructor == null) {
+            return false;
+        }
+        var params = constructor.getParameterTypes();
+        return params.length == 11
+                && params[0] == int.class
+                && params[1] == int.class
+                && "android.os.UserHandle".equals(params[2].getName())
+                && "android.content.ComponentName".equals(params[3].getName())
+                && params[4] == int.class
+                && "android.graphics.Rect".equals(params[5].getName())
+                && "android.graphics.Insets".equals(params[6].getName())
+                && "android.graphics.Bitmap".equals(params[7].getName())
+                && params[8] == int.class
+                && params[9] == boolean.class
+                && params[10] == boolean.class;
+    }
+
+    static boolean clearWorkProfileSecureLayer(Object[] args) {
+        if (args == null || args.length <= SECURE_LAYER_ARG_INDEX) {
+            return false;
+        }
+        var typeArg = args[TYPE_ARG_INDEX];
+        if (!(typeArg instanceof Integer type) || type != WORK_PROFILE_SCREENSHOT_TYPE) {
+            return false;
+        }
+        var current = args[SECURE_LAYER_ARG_INDEX];
+        if (!(current instanceof Boolean secureLayer) || !secureLayer) {
+            return false;
+        }
+        args[SECURE_LAYER_ARG_INDEX] = false;
+        return true;
+    }
+}

--- a/app/src/main/java/io/github/lsposed/disableflagsecure/OneUiWmScreenshotHook.java
+++ b/app/src/main/java/io/github/lsposed/disableflagsecure/OneUiWmScreenshotHook.java
@@ -1,0 +1,89 @@
+package io.github.lsposed.disableflagsecure;
+
+import android.graphics.Bitmap;
+import android.graphics.Rect;
+import android.os.IBinder;
+import android.view.SurfaceControl;
+
+import java.lang.reflect.Method;
+
+final class OneUiWmScreenshotHook {
+    static final int SECURE_CONTENT_POLICY_ARG_INDEX = 5;
+
+    private static final String POLICY_METHOD_NAME = "isScreenshotAllowedByPolicy";
+    private static final String SCREENSHOT_METHOD_NAME = "screenshot";
+    private static final String REASON_FOR_FAILURE_FIELD = "mReasonForFailure";
+    private static final int REASON_FLAG_SECURE = 16;
+    private static final int REASON_MDM = 32;
+
+    private OneUiWmScreenshotHook() {
+    }
+
+    static boolean isScreenshotAllowedByPolicyMethod(Method method) {
+        if (method == null || !POLICY_METHOD_NAME.equals(method.getName())) {
+            return false;
+        }
+        if (method.getReturnType() != boolean.class) {
+            return false;
+        }
+        var params = method.getParameterTypes();
+        return params.length == 1 && "DisplayContent".equals(params[0].getSimpleName());
+    }
+
+    static boolean isPrimaryProfileScreenshotMethod(Method method) {
+        if (method == null || !SCREENSHOT_METHOD_NAME.equals(method.getName())) {
+            return false;
+        }
+        if (method.getReturnType() != Bitmap.class) {
+            return false;
+        }
+        var params = method.getParameterTypes();
+        return params.length == 7
+                && params[0] == IBinder.class
+                && params[1] == Rect.class
+                && params[2] == int.class
+                && params[3] == int.class
+                && params[4] == SurfaceControl.class
+                && params[5] == boolean.class
+                && params[6] == SurfaceControl[].class;
+    }
+
+    static boolean narrowScreenshotPolicyResult(Object controller, boolean originalAllowed) {
+        if (originalAllowed) {
+            return true;
+        }
+        var reason = readReasonForFailure(controller);
+        if (reason == null) {
+            return false;
+        }
+        return (reason & REASON_FLAG_SECURE) != 0 && (reason & REASON_MDM) == 0;
+    }
+
+    private static Integer readReasonForFailure(Object controller) {
+        if (controller == null) {
+            return null;
+        }
+        try {
+            var field = controller.getClass().getDeclaredField(REASON_FOR_FAILURE_FIELD);
+            if (field.getType() != int.class) {
+                return null;
+            }
+            field.setAccessible(true);
+            return field.getInt(controller);
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            return null;
+        }
+    }
+
+    static boolean forceIgnoreSecureContentPolicy(Object[] args) {
+        if (args == null || args.length <= SECURE_CONTENT_POLICY_ARG_INDEX) {
+            return false;
+        }
+        var current = args[SECURE_CONTENT_POLICY_ARG_INDEX];
+        if (!(current instanceof Boolean ignorePolicy) || ignorePolicy) {
+            return false;
+        }
+        args[SECURE_CONTENT_POLICY_ARG_INDEX] = true;
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes screenshots and built-in screen recording for `FLAG_SECURE` apps on Samsung One UI 8 / Android 16.

- Hooks Samsung `WmScreenshotController` policy and secure-content capture path.
- Returns `false` from `WindowState.isSecureLocked()` so secure layers can also be mirrored by Samsung Screen Recorder.

Tested on Galaxy S25 (SM-S931B), One UI 8.5 / Android 16: screenshots and screen recordings work.

> Note: this intentionally disables app-level `FLAG_SECURE` protection globally.

Related to #93 